### PR TITLE
Unary constructor no paren

### DIFF
--- a/docs/examples/beta2.mlts
+++ b/docs/examples/beta2.mlts
@@ -8,7 +8,7 @@ let rec subst t x u =
   | nab X in (X, X) -> u
   | nab X Y in (X, Y) -> Y
   | (x, App(m, n)) -> App(subst m x u, subst n x u)
-  | (x, Abt(r)) -> Abt(y \ subst (r @ y) x u)
+  | (x, Abt r) -> Abt(y \ subst (r @ y) x u)
 ;;
 
 let rec beta t =
@@ -18,10 +18,10 @@ let rec beta t =
     let n = beta n in
     begin 
         match m with
-        | Abt(r) -> new X in beta (subst (r @ X) X n)
+        | Abt r -> new X in beta (subst (r @ X) X n)
         | w -> App(m, n)
     end
-  | Abt(r) -> Abt (y \ beta (r @ y))
+  | Abt r -> Abt (y \ beta (r @ y))
   | nab X in X -> X
 ;;
 

--- a/lib/mlts_api/mltsParser.mly
+++ b/lib/mlts_api/mltsParser.mly
@@ -165,10 +165,7 @@ pattern:
       				        { PApp(v, l) }
 					
 | p1 = pattern; DCOLON; p2 = pattern	{ PListCons(p1, p2) }
-| BEGIN; p1 = pattern; COMMA; p2 = pattern; END
-  	      	       	      	   	{ PPair(p1, p2) }
-/*| c = constr_path; s = simple_pattern
-					{ PConstr(c, [s]) }*/
+| c = constr_path; p = trivial_pattern  { PConstr(c, [p]) }
 | c = constr_path;
     BEGIN;
     l = separated_nonempty_list(COMMA, pattern);
@@ -178,9 +175,15 @@ pattern:
 
 simple_pattern:
 | BEGIN; p = pattern; END		{ p }
-| c = constr_path;			{ PConstr(c, []) }
+| BEGIN; p1 = pattern; COMMA; p2 = pattern; END
+                                        { PPair(p1, p2) }
+| trivial_pattern                       { $1 }
+
+trivial_pattern:
+| constr_path   			{ PConstr($1, []) }
 | constant				{ PConstant($1) }
 | value_path				{ PVal($1) }
+
 
 
 constant:

--- a/lib/mlts_api/mltsParser.mly
+++ b/lib/mlts_api/mltsParser.mly
@@ -129,14 +129,15 @@ expr:
 | i = value_name; BACKSLASH; e = expr
       %prec BACKSLASH			{ EBind(i, e) }
       
-| c = constr_path; s = trivial_expr
-					{ EConstr(c, [s]) }
-    
 | c = constr_path;
-    BEGIN;
-    l = expr_list;
-    END;				{ EConstr(c, l) }
+  args = constr_expr_args               { EConstr(c, args) }
 ;
+
+constr_expr_args:
+| s = trivial_expr                      { [s] }
+| BEGIN; l = expr_list; END;		{ l }
+;
+
 
 expr_list:
 | expr	{ [$1] }
@@ -180,26 +181,26 @@ pattern:
       				        { PApp(v, l) }
 					
 | p1 = pattern; DCOLON; p2 = pattern	{ PListCons(p1, p2) }
-| c = constr_path; p = trivial_pattern  { PConstr(c, [p]) }
-| c = constr_path;
-    BEGIN;
-    l = separated_nonempty_list(COMMA, pattern);
-    END;
-					{ PConstr(c, l) }
+| c = constr_path; l = constr_pat_args  { PConstr(c, l) }
+;
+
+constr_pat_args:
+| p = trivial_pattern                   { [p] }
+| BEGIN; l = separated_nonempty_list(COMMA, pattern); END;
+					{ l }
 ;
 
 simple_pattern:
+| trivial_pattern                       { $1 }
 | BEGIN; p = pattern; END		{ p }
 | BEGIN; p1 = pattern; COMMA; p2 = pattern; END
-                                        { PPair(p1, p2) }
-| trivial_pattern                       { $1 }
+;                                        { PPair(p1, p2) }
 
 trivial_pattern:
 | constr_path   			{ PConstr($1, []) }
 | constant				{ PConstant($1) }
 | value_path				{ PVal($1) }
-
-
+;
 
 constant:
 | CONST_INT				{ Int($1) }


### PR DESCRIPTION
This PR lets us use a unary constructor without parenthesizing the argument: `Abt(r)` can be written `Abt r`, in both pattern and expression contexts.

Note that I'm not sure this is an improvement syntax-wise: I find the syntax of OCaml constructors ugly (I would rather use a curried syntax `App m n` than `App(m,n)`) and this PR adds a special case to it. Yet it may be interesting to manage the expectations of people writing examples coming from the OCaml community -- I naturally used un-parenthesized unary patterns for `Abt r`.
